### PR TITLE
Update xemu.md

### DIFF
--- a/docs/emulators/steamos/xemu.md
+++ b/docs/emulators/steamos/xemu.md
@@ -248,7 +248,7 @@ Note: Cannot be *built* on the Steam Deck, but can be built elsewhere and copied
 
          # Install dependencies
          # Example for Arch:
-         sudo pacman -Syu build-essential cmake
+         sudo pacman -Syu --needed base-devel cmake
 
          # Clone Repo
          git clone https://github.com/XboxDev/extract-xiso.git


### PR DESCRIPTION
Corrected the package name for the system compilers as well as add a "--needed" flag to prevent reinstalling packages that may already be installed on the system from the "base" group.